### PR TITLE
refactor: remove shimmer placeholder effect

### DIFF
--- a/app/src/main/java/com/aubynsamuel/androidEssentials/presentation/screens/bars_and_navigation/TopAppBar.kt
+++ b/app/src/main/java/com/aubynsamuel/androidEssentials/presentation/screens/bars_and_navigation/TopAppBar.kt
@@ -2,17 +2,13 @@ package com.aubynsamuel.androidEssentials.presentation.screens.bars_and_navigati
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ToggleOff
@@ -28,19 +24,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.aubynsamuel.skeletonloader.modifiers.shimmerPlaceholder
-import kotlinx.coroutines.delay
 
 @RequiresApi(Build.VERSION_CODES.S)
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
@@ -48,12 +36,6 @@ import kotlinx.coroutines.delay
 fun TopApBarScreen() {
     val scrollState = rememberScrollState()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
-    var isLoading by remember { mutableStateOf(true) }
-
-    LaunchedEffect(Unit) {
-        delay(5000)
-        isLoading = false
-    }
 
     Scaffold(
         topBar = {
@@ -69,7 +51,6 @@ fun TopApBarScreen() {
                     }
                 }
             )
-
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
     ) { inner ->
@@ -84,25 +65,15 @@ fun TopApBarScreen() {
             Text(
                 text = "Welcome to CardIt",
                 style = MaterialTheme.typography.headlineMedium,
-                modifier = Modifier
-                    .shimmerPlaceholder(isLoading)
             )
 
             Spacer(modifier = Modifier.height(24.dp))
-
-            Box(
-                modifier = Modifier
-                    .size(200.dp)
-                    .shimmerPlaceholder(isLoading, shape = CircleShape)
-                    .background(Color.Red)
-            )
 
             repeat(10) { index ->
                 Card(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(vertical = 8.dp)
-                        .shimmerPlaceholder(isLoading)
                 ) {
                     Column(
                         modifier = Modifier
@@ -111,22 +82,17 @@ fun TopApBarScreen() {
                         Text(
                             text = "Card Item ${index + 1}",
                             style = MaterialTheme.typography.titleMedium,
-                            modifier = Modifier
-                                .shimmerPlaceholder(isLoading)
                         )
                         Spacer(modifier = Modifier.height(8.dp))
                         Text(
                             text = "This is some sample content for card ${index + 1}. It contains generic information that you can replace later with actual content.",
                             style = MaterialTheme.typography.bodyMedium,
-                            modifier = Modifier
-                                .shimmerPlaceholder(isLoading)
                         )
                         Spacer(modifier = Modifier.height(8.dp))
                         Button(
                             onClick = { },
                             modifier = Modifier
                                 .align(Alignment.End)
-                                .shimmerPlaceholder(isLoading)
 
                         ) {
                             Text("Action ${index + 1}")
@@ -141,7 +107,6 @@ fun TopApBarScreen() {
                 onClick = { },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .shimmerPlaceholder(isLoading)
             ) {
                 Text("Load More")
             }


### PR DESCRIPTION
Removed the shimmer placeholder loading effect from the `TopApBarScreen`. This includes the removal of the loading state logic, the associated `shimmerPlaceholder` modifier from various UI components, and unused imports.